### PR TITLE
Test flashloan attack

### DIFF
--- a/contracts/FlashloanAttacker.sol
+++ b/contracts/FlashloanAttacker.sol
@@ -1,0 +1,75 @@
+pragma solidity 0.6.12;
+
+import "../interfaces/yearn/IVault.sol";
+import {IERC20, Address, SafeERC20} from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../interfaces/UniswapInterfaces/IUniswapV2Router02.sol";
+import "../../interfaces/UniswapInterfaces/IUniswapV2Pair.sol";
+
+contract FlashloanAttacker {
+    using SafeERC20 for IERC20;
+
+    IVault public vault;
+
+    IERC20 public constant dai = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    IERC20 public constant usdc = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    IUniswapV2Router02 router = IUniswapV2Router02(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
+    IUniswapV2Pair pair = IUniswapV2Pair(0xAE461cA67B15dc8dc81CE7615e0320dA1A9aB8D5);
+
+    constructor(IVault _vault) public {
+        vault = _vault;
+    }
+
+    function depositAll() public {
+        // Deposit all the DAI
+        uint256 amount = dai.balanceOf(address(this));
+        dai.safeApprove(address(vault), amount);
+        vault.deposit(dai.balanceOf(address(this)));
+    }
+
+    function performAttack() public {
+        uint256 daiIn = dai.balanceOf(address(this));
+
+        address[] memory path = new address[](2);
+        path[0] = address(dai);
+        path[1] = address(usdc);
+
+        uint256[] memory amounts = router.getAmountsOut(daiIn, path);
+        uint256 usdcOut = amounts[1];
+
+        bytes memory data = abi.encode(daiIn);
+
+        // Call swap to receive USDC from Pair
+        address token0 = pair.token0();
+        if (token0 == address(dai)) {
+            pair.swap(0, usdcOut, address(this), data);
+        } else {
+            pair.swap(usdcOut, 0, address(this), data);
+        }
+    }
+
+    function uniswapV2Call(
+        address sender,
+        uint256 amount0,
+        uint256 amount1,
+        bytes calldata data
+    ) 
+        public 
+    {
+        assert(msg.sender == address(pair)); // ensure that msg.sender is a V2 pair
+
+        // Withdraw all from vault
+        vault.withdraw();
+
+        // At the end of uniswapV2Call, contracts must return enough tokens to the pair to make it whole.
+        // Specifically, this means that the product of the pair reserves after the swap, discounting all token amounts
+        // sent by 0.3% LP fee, must be greater than before.
+
+        // In the case where the token withdrawn is not the token returned (i.e. DAI was requested in the flash swap, and WETH
+        // was returned, or vice versa), the fee simplifies to the simple swap case. This means that the standard getAmountIn
+        // pricing function should be used to calculate e.g., the amount of WETH that must be returned in exchange for the amount
+        // of DAI that was requested out.
+
+        uint256 daiIn = abi.decode(data, (uint256));
+        dai.transfer(msg.sender, daiIn);
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,6 +174,14 @@ def dai_whale(accounts):
     #binanace 8:
     yield accounts.at("0xf977814e90da44bfa03b6295a0616a897441acec", force=True)
 
+
+@pytest.fixture
+def usdc_whale(accounts):
+    #binance peg tokens:
+    #yield accounts.at("0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503", force=True)
+    #binanace 8:
+    yield accounts.at("0x40ec5b33f54e0e8a33a975908c5ba1c14e5bbbdf", force=True)
+
 @pytest.fixture
 def yvDAI():
     vault_address = "0xdA816459F1AB5631232FE5e97a05BBBb94970c95"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -479,3 +479,8 @@ def cloner(
      #   price_oracle_want_to_eth,
     )
     yield cloner
+
+
+@pytest.fixture
+def flashloan_attacker(FlashloanAttacker, vault, strategist):
+    yield FlashloanAttacker.deploy(vault.address, {'from': strategist})

--- a/tests/test_flashloan_attack.py
+++ b/tests/test_flashloan_attack.py
@@ -1,0 +1,38 @@
+import pytest
+from brownie import chain, reverts, Wei
+
+wad = 10 ** 18
+
+
+def test_flashloan_attack(
+    gov, chain, accounts, token, vault, strategy, user, amount, RELATIVE_APPROX, token_whale, strategist, router, unirouter, dai, dai_whale, yieldBearing, amountBIGTIME, amountBIGTIME2, user2, RELATIVE_APPROX_LOSSY, flashloan_attacker
+):
+    # Deposit to the vault
+    user_balance_before = token.balanceOf(user)
+    token.approve(vault.address, amount, {"from": user})
+    vault.deposit(amount, {"from": user})
+    assert token.balanceOf(vault.address) == amount
+
+    # Transfer 200K DAI tokens to deposit in vault
+    token.transfer(flashloan_attacker.address, amountBIGTIME, {'from': dai_whale})
+    
+    # Deposit all to vault
+    flashloan_attacker.depositAll({'from': strategist})
+
+    # Transfer 1M DAI tokens to attacker to prepare for attack
+    token.transfer(flashloan_attacker.address, amountBIGTIME2, {'from': dai_whale})
+
+    # Attack; Withdraw after forcing a pool imbalance
+    flashloan_attacker.performAttack({'from': strategist})
+
+    # harvest
+    chain.sleep(1)
+    strategy.harvest({"from": gov})
+    assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
+
+    # tend({"from": gov})
+    strategy.tend({"from": gov})
+
+    # withdrawal
+    vault.withdraw({"from": user})
+    assert ( pytest.approx(token.balanceOf(user), rel=RELATIVE_APPROX) == user_balance_before )

--- a/tests/test_flashloan_attack.py
+++ b/tests/test_flashloan_attack.py
@@ -1,10 +1,11 @@
+import brownie
 import pytest
 from brownie import chain, reverts, Wei
 
 wad = 10 ** 18
 
 
-def DISABLED_flashloan_attack(
+def test_flashloan_attack_when_levered_up(
     gov, chain, accounts, token, vault, strategy, user, amount, RELATIVE_APPROX, token_whale, strategist, router, unirouter, dai, dai_whale, yieldBearing, amountBIGTIME, amountBIGTIME2, user2, RELATIVE_APPROX_LOSSY, flashloan_attacker
 ):
     # Deposit to the vault
@@ -19,68 +20,13 @@ def DISABLED_flashloan_attack(
     # Deposit all to vault
     flashloan_attacker.depositAll({'from': strategist})
 
+    # Lever up; Open the maker position
+    chain.sleep(1)
+    strategy.harvest({"from": gov})
+
     # Transfer 1M DAI tokens to attacker to prepare for attack
     token.transfer(flashloan_attacker.address, amountBIGTIME2, {'from': dai_whale})
 
     # Attack; Withdraw after forcing a pool imbalance
-    flashloan_attacker.performAttack({'from': strategist})
-
-    flashloan_attacker_balance = token.balanceOf(flashloan_attacker.address)
-    print(flashloan_attacker_balance)
-
-    assert True == False
-
-    # harvest
-    chain.sleep(1)
-    strategy.harvest({"from": gov})
-    assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
-
-    # tend({"from": gov})
-    strategy.tend({"from": gov})
-
-    # withdrawal
-    vault.withdraw({"from": user})
-    assert ( pytest.approx(token.balanceOf(user), rel=RELATIVE_APPROX) == user_balance_before )
-
-
-def test_pool_drain_attack(
-    gov, chain, accounts, token, partnerToken, usdc_whale, vault, strategy, user, amount, RELATIVE_APPROX, token_whale, strategist, router, unirouter, dai, dai_whale, yieldBearing, amountBIGTIME, amountBIGTIME2, user2, RELATIVE_APPROX_LOSSY, flashloan_attacker
-):
-    # Deposit to the vault
-    user_balance_before = token.balanceOf(user)
-    token.approve(vault.address, amount, {"from": user})
-    vault.deposit(amount, {"from": user})
-    assert token.balanceOf(vault.address) == amount
-
-    # Transfer 200K DAI tokens to deposit in vault
-    token.transfer(flashloan_attacker.address, amountBIGTIME, {'from': dai_whale})
-    
-    # Deposit all to vault
-    flashloan_attacker.depositAll({'from': strategist})
-
-    # Transfer 1M DAI tokens to attacker to prepare for attack
-    token.transfer(flashloan_attacker.address, amountBIGTIME2, {'from': dai_whale})
-
-    # Transfer 1M DAI tokens to attacker to prepare for attack
-    partnerToken.transfer(flashloan_attacker.address, amountBIGTIME2 / 10 ** 12, {'from': usdc_whale})
-
-
-    # Attack; Withdraw after forcing a pool imbalance
-    flashloan_attacker.performPoolDrainAttack({'from': strategist})
-
-    flashloan_attacker_balance = token.balanceOf(flashloan_attacker.address)
-    print(flashloan_attacker_balance)
-
-    assert True == False
-
-    # harvest
-    chain.sleep(1)
-    strategy.harvest({"from": gov})
-    assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
-
-    # tend({"from": gov})
-    strategy.tend({"from": gov})
-
-    # withdrawal
-    vault.withdraw({"from": user})
-    assert ( pytest.approx(token.balanceOf(user), rel=RELATIVE_APPROX) == user_balance_before )
+    with brownie.reverts(""):
+        flashloan_attacker.performAttack({'from': strategist})

--- a/tests/test_flashloan_attack.py
+++ b/tests/test_flashloan_attack.py
@@ -4,7 +4,7 @@ from brownie import chain, reverts, Wei
 wad = 10 ** 18
 
 
-def test_flashloan_attack(
+def DISABLED_flashloan_attack(
     gov, chain, accounts, token, vault, strategy, user, amount, RELATIVE_APPROX, token_whale, strategist, router, unirouter, dai, dai_whale, yieldBearing, amountBIGTIME, amountBIGTIME2, user2, RELATIVE_APPROX_LOSSY, flashloan_attacker
 ):
     # Deposit to the vault
@@ -24,6 +24,54 @@ def test_flashloan_attack(
 
     # Attack; Withdraw after forcing a pool imbalance
     flashloan_attacker.performAttack({'from': strategist})
+
+    flashloan_attacker_balance = token.balanceOf(flashloan_attacker.address)
+    print(flashloan_attacker_balance)
+
+    assert True == False
+
+    # harvest
+    chain.sleep(1)
+    strategy.harvest({"from": gov})
+    assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
+
+    # tend({"from": gov})
+    strategy.tend({"from": gov})
+
+    # withdrawal
+    vault.withdraw({"from": user})
+    assert ( pytest.approx(token.balanceOf(user), rel=RELATIVE_APPROX) == user_balance_before )
+
+
+def test_pool_drain_attack(
+    gov, chain, accounts, token, partnerToken, usdc_whale, vault, strategy, user, amount, RELATIVE_APPROX, token_whale, strategist, router, unirouter, dai, dai_whale, yieldBearing, amountBIGTIME, amountBIGTIME2, user2, RELATIVE_APPROX_LOSSY, flashloan_attacker
+):
+    # Deposit to the vault
+    user_balance_before = token.balanceOf(user)
+    token.approve(vault.address, amount, {"from": user})
+    vault.deposit(amount, {"from": user})
+    assert token.balanceOf(vault.address) == amount
+
+    # Transfer 200K DAI tokens to deposit in vault
+    token.transfer(flashloan_attacker.address, amountBIGTIME, {'from': dai_whale})
+    
+    # Deposit all to vault
+    flashloan_attacker.depositAll({'from': strategist})
+
+    # Transfer 1M DAI tokens to attacker to prepare for attack
+    token.transfer(flashloan_attacker.address, amountBIGTIME2, {'from': dai_whale})
+
+    # Transfer 1M DAI tokens to attacker to prepare for attack
+    partnerToken.transfer(flashloan_attacker.address, amountBIGTIME2 / 10 ** 12, {'from': usdc_whale})
+
+
+    # Attack; Withdraw after forcing a pool imbalance
+    flashloan_attacker.performPoolDrainAttack({'from': strategist})
+
+    flashloan_attacker_balance = token.balanceOf(flashloan_attacker.address)
+    print(flashloan_attacker_balance)
+
+    assert True == False
 
     # harvest
     chain.sleep(1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,65 @@
+
+ether = 10 ** 18
+
+def print_state(message, vault, strategy, user, token, partnerToken, yieldBearing):
+    print('-' * 5, message, '-' * 5)
+    print('DAI Balances')
+    print('User :', token.balanceOf(user.address) / ether)
+    print('Vault:', token.balanceOf(vault.address) / ether)
+    print('Strat:', token.balanceOf(strategy.address) / ether)
+    print('\n')
+
+    print('USDC Balances')
+    print('User :', partnerToken.balanceOf(user.address) / 10 ** 6)
+    print('Vault:', partnerToken.balanceOf(vault.address) / 10 ** 6)
+    print('Strat:', partnerToken.balanceOf(strategy.address) / 10 ** 6)
+    print('\n')
+
+    print('Vault')
+    print('User shares:', vault.balanceOf(user.address) / ether)
+    print('maxAvailableShares', vault.maxAvailableShares() / ether)
+    print('pricePerShare', vault.pricePerShare() / ether)
+    print('\n')
+
+    print('Strategy')
+    (
+        performanceFee,
+        activation,
+        debtRatio,
+        minDebtPerHarvest,
+        maxDebtPerHarvest,
+        lastReport,
+        totalDebt,
+        totalGain,
+        totalLoss
+    ) = vault.strategies(strategy.address)
+    print('totalDebt', totalDebt / ether)
+    print('totalGain', totalGain / ether)
+    print('totalLoss', totalLoss / ether)
+    print('lastReport', lastReport)
+    print('estimatedTotalAssets', strategy.estimatedTotalAssets() / ether)
+    print('\n')
+
+    print('Strategy Position on Maker')
+    print('getUnitLpTokenValue', strategy.getUnitLpTokenValue() / ether)
+    (collatBalance, debtBalance) = strategy.getCurrentPosition()
+    print('getCurrentPosition', collatBalance / ether, debtBalance / ether)
+    (collatValue, debtValue) = strategy.getCurrentPositionValues()
+    print('getCurrentPositionValues', collatValue / ether, debtValue / ether)
+    print('getCurrentCollatRatio', strategy.getCurrentCollatRatio() / ether)
+    print('\n')
+
+    print('DAIUSDC Pool')
+    (dai_reserve, usdc_reserve) = yieldBearing.getReserves()
+    print('Dai  reserve', dai_reserve / ether)
+    print('Dai  balance', token.balanceOf(user.address) / ether)
+    print('usdc reserve', usdc_reserve / 10 ** 6)
+    print('usdc balance', partnerToken.balanceOf(user.address) / 10 ** 6)
+    print('\n')
+
+    print('DAIUSDC balances')    
+    print('User :', yieldBearing.balanceOf(user.address) / ether)
+    print('Vault:', yieldBearing.balanceOf(vault.address) / ether)
+    print('Strat:', yieldBearing.balanceOf(strategy.address) / ether)
+    print('Maker:', yieldBearing.balanceOf(vault.address) / ether)
+    print('\n')


### PR DESCRIPTION
### Problem statement
What if an attacker through a smart contract (that has a lot of non-flashloaned DAI already deposited in yvDAI in a previous block) swaps a crazy amount of additional DAI (could be flashloaned) and swaps it for USDC in the UNIV2-pool, but before the swap function arrives at _update, the transfer of the tokens triggers atomically a function of the attacker's smart contract that withdraws a lot of yvDAI with the withdraw function. Then would the imbalanced pool have any way of messing up internal accounting in liquidatePosition()?

### Solution
Uniswap V2 flow:
1. Attacker calls swap for taking flashloan
2. Uniswap Pair contract sets unlocked = false in the [`lock` modifier](https://github.com/Uniswap/v2-core/blob/ee547b17853e71ed4e0101ccfd52e70d5acded58/contracts/UniswapV2Pair.sol#L33)
3. [Transfer out tokens to caller](https://github.com/Uniswap/v2-core/blob/ee547b17853e71ed4e0101ccfd52e70d5acded58/contracts/UniswapV2Pair.sol#L170)
4. [Allow caller to execute custom logic in callback and return tokens to pair contract (either the flash swapped tokens or the other token in the pair](https://github.com/Uniswap/v2-core/blob/ee547b17853e71ed4e0101ccfd52e70d5acded58/contracts/UniswapV2Pair.sol#L172)
5. Caller calls withdraw which calls `Pair.burn()`, but it reverts because [burn has the `lock` modifier and requires unlocked = true](https://github.com/Uniswap/v2-core/blob/ee547b17853e71ed4e0101ccfd52e70d5acded58/contracts/UniswapV2Pair.sol#L134). 


### Extra
#### Analyzing removing liquidity when the pools are imbalanced in previous blocks

Say, reserves are 100 USDC and 200 DAI
then, 1 USDC = 2 DAI.
Let total supply of pair token be 10 and strategy contract wants to remove liquidity by burning 1 LP token.
Then tokens returned = 10 USDC and 20 DAI.
The strategy contract then swaps 10 USDC for 10 DAI in PSM. Total 30 DAI. (which is same as if the pool was perfectly 50-50).

Similarly, if reserves are 200 USDC and 100 DAI
then, 1 DAI = 2 USDC
Total supply be 10 and remove liquidity by burning 1 LP token
Then tokens returned = 20 USDC and 10 DAI
Swap 20 USDC for 20 DAI in PSM. Total 30 DAI.